### PR TITLE
Fix id increment for doctors and add tests

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -88,7 +88,7 @@ The table below summarises the rules and constraints for all input fields used a
 <box type="info" seamless>
 
 **Additional assumptions:**
-* **Doctor duplicate detection:** Two doctors are considered duplicates if they share the same name (case-insensitive) **and** either the same phone number or the same email.
+* **Doctor duplicate detection:** Two doctors are considered duplicates if they share the same phone number **or** the same email, regardless of name. Doctors with the same name but different phone numbers and emails are allowed.
 * **Patient duplicate detection:** Two patients are considered duplicates if they share the same name (case-insensitive) **and** the same email.
 * **Schedule window:** Doctor schedules are displayed and bookable for a rolling 7-day window from today.
 * **Doctor IDs:** Each doctor is automatically assigned a unique, persistent ID that is preserved across edits. IDs are not user-editable.

--- a/src/main/java/seedu/address/logic/commands/AddDocCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddDocCommand.java
@@ -51,6 +51,7 @@ public class AddDocCommand extends Command {
         requireNonNull(model);
 
         if (model.hasDoctor(toAdd)) {
+            Doctor.setIdTracker(toAdd.getDocId());
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddPatCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddPatCommand.java
@@ -54,6 +54,7 @@ public class AddPatCommand extends Command {
         logger.info("Executing AddPatCommand with patient: " + Messages.format(toAdd));
 
         if (model.hasPatient(toAdd)) {
+            Patient.setIdTracker(toAdd.getPatientId());
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 

--- a/src/main/java/seedu/address/model/person/Doctor.java
+++ b/src/main/java/seedu/address/model/person/Doctor.java
@@ -59,8 +59,7 @@ public class Doctor extends Person {
     }
 
     /**
-     * Returns true if both doctors have the same name (case-insensitive)
-     * and share the same phone number or email.
+     * Returns true if both doctors share the same phone number or the same email.
      */
     @Override
     public boolean isSamePerson(Person otherPerson) {
@@ -72,8 +71,7 @@ public class Doctor extends Person {
             return false;
         }
 
-        return otherPerson.getName().fullName.equalsIgnoreCase(getName().fullName)
-                && (otherPerson.getPhone().equals(getPhone())
-                    || otherPerson.getEmail().equals(getEmail()));
+        return otherPerson.getPhone().equals(getPhone())
+                || otherPerson.getEmail().equals(getEmail());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/AddDocCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddDocCommandTest.java
@@ -133,7 +133,7 @@ public class AddDocCommandTest {
     }
 
     @Test
-    public void execute_differentNameSameEmail_success() throws Exception {
+    public void execute_differentNameSameEmail_throwsCommandException() throws Exception {
         Model model = new ModelManager();
 
         Doctor doctor = new DoctorBuilder().withName("Shrek")
@@ -147,16 +147,11 @@ public class AddDocCommandTest {
 
         model.addDoctor(doctor);
         AddDocCommand addDocCommand = new AddDocCommand(differentDoctor);
-        Model expectedModel = new ModelManager();
-        expectedModel.addDoctor(doctor);
-        expectedModel.addDoctor(differentDoctor);
-        assertCommandSuccess(addDocCommand, model,
-                String.format(AddDocCommand.MESSAGE_SUCCESS, Messages.format(differentDoctor)),
-                expectedModel);
+        assertCommandFailure(addDocCommand, model, AddDocCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test
-    public void execute_differentNameSamePhone_success() throws Exception {
+    public void execute_differentNameSamePhone_throwsCommandException() throws Exception {
         Model model = new ModelManager();
 
         Doctor doctor = new DoctorBuilder().withName("Jerry")
@@ -170,12 +165,7 @@ public class AddDocCommandTest {
 
         model.addDoctor(doctor);
         AddDocCommand addDocCommand = new AddDocCommand(differentDoctor);
-        Model expectedModel = new ModelManager();
-        expectedModel.addDoctor(doctor);
-        expectedModel.addDoctor(differentDoctor);
-        assertCommandSuccess(addDocCommand, model,
-                String.format(AddDocCommand.MESSAGE_SUCCESS, Messages.format(differentDoctor)),
-                expectedModel);
+        assertCommandFailure(addDocCommand, model, AddDocCommand.MESSAGE_DUPLICATE_PERSON);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/DeleteDocCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteDocCommandTest.java
@@ -89,13 +89,26 @@ public class DeleteDocCommandTest {
     @Test
     public void execute_scheduleIoError_throwsCommandException() throws Exception {
         File scheduleFile = new File("data/schedule.json");
-        byte[] backup = Files.readAllBytes(scheduleFile.toPath());
+        boolean created = false;
+        byte[] backup = null;
+        if (scheduleFile.exists()) {
+            backup = Files.readAllBytes(scheduleFile.toPath());
+        } else {
+            scheduleFile.getParentFile().mkdirs();
+            Files.writeString(scheduleFile.toPath(), "{}");
+            backup = "{}".getBytes();
+            created = true;
+        }
         try {
             Files.writeString(scheduleFile.toPath(), "not valid json");
             DeleteDocCommand deleteDocCommand = new DeleteDocCommand(INDEX_FIRST_PERSON);
             assertThrows(CommandException.class, () -> deleteDocCommand.execute(model));
         } finally {
-            Files.write(scheduleFile.toPath(), backup);
+            if (created) {
+                scheduleFile.delete();
+            } else {
+                Files.write(scheduleFile.toPath(), backup);
+            }
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/EditDocCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditDocCommandTest.java
@@ -203,7 +203,16 @@ public class EditDocCommandTest {
     @Test
     public void execute_scheduleIoError_throwsCommandException() throws Exception {
         File scheduleFile = new File("data/schedule.json");
-        byte[] backup = Files.readAllBytes(scheduleFile.toPath());
+        boolean created = false;
+        byte[] backup = null;
+        if (scheduleFile.exists()) {
+            backup = Files.readAllBytes(scheduleFile.toPath());
+        } else {
+            scheduleFile.getParentFile().mkdirs();
+            Files.writeString(scheduleFile.toPath(), "{}");
+            backup = "{}".getBytes();
+            created = true;
+        }
         try {
             Files.writeString(scheduleFile.toPath(), "not valid json");
             EditDoctorDescriptor descriptor = new EditDoctorDescriptorBuilder()
@@ -211,7 +220,11 @@ public class EditDocCommandTest {
             EditDocCommand editDocCommand = new EditDocCommand(INDEX_FIRST_PERSON, descriptor);
             assertThrows(CommandException.class, () -> editDocCommand.execute(model));
         } finally {
-            Files.write(scheduleFile.toPath(), backup);
+            if (created) {
+                scheduleFile.delete();
+            } else {
+                Files.write(scheduleFile.toPath(), backup);
+            }
         }
     }
 

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -179,8 +179,8 @@ public class ModelManagerTest {
                 .withEmail("mcd@doc.com").withAddress("Old Road").build();
         modelManager.addDoctor(oldDoc);
 
-        Doctor newDoc = new DoctorBuilder().withName("Kentucky").withPhone("44445555")
-                .withEmail("mcd@doc.com").withAddress("Chicken Road").build();
+        Doctor newDoc = new DoctorBuilder().withName("Kentucky").withPhone("66667777")
+                .withEmail("kfc@doc.com").withAddress("Chicken Road").build();
         modelManager.setDoctor(oldDoc, newDoc);
 
         assertFalse(modelManager.hasDoctor(oldDoc));
@@ -303,11 +303,13 @@ public class ModelManagerTest {
 
     @Test
     public void setDoctor_doctorExists_doctorUpdatedSuccessfully() {
-        Doctor doctor = new DoctorBuilder().withName("Doc One").build();
+        Doctor doctor = new DoctorBuilder().withName("Doc One").withPhone("11112222")
+                .withEmail("docone@doc.com").build();
         modelManager.addDoctor(doctor);
         assertTrue(modelManager.hasPerson(doctor));
 
-        Doctor updatedDoctor = new DoctorBuilder().withName("Doc One Updated").build();
+        Doctor updatedDoctor = new DoctorBuilder().withName("Doc One Updated").withPhone("33334444")
+                .withEmail("doconeupdated@doc.com").build();
         modelManager.setDoctor(doctor, updatedDoctor);
         assertFalse(modelManager.hasPerson(doctor));
         assertTrue(modelManager.hasPerson(updatedDoctor));

--- a/src/test/java/seedu/address/model/person/DoctorTest.java
+++ b/src/test/java/seedu/address/model/person/DoctorTest.java
@@ -152,11 +152,20 @@ public class DoctorTest {
     }
 
     @Test
-    public void isSamePerson_differentName_returnsFalse() {
+    public void isSamePerson_differentNameSamePhoneAndEmail_returnsTrue() {
         Doctor alice = new DoctorBuilder().withName("Alice").withPhone("12121212")
                 .withEmail("alice@wonderland.com").build();
         Doctor other = new DoctorBuilder().withName("Bob").withPhone("12121212")
                 .withEmail("alice@wonderland.com").build();
+        assertTrue(alice.isSamePerson(other));
+    }
+
+    @Test
+    public void isSamePerson_differentNameDifferentPhoneEmail_returnsFalse() {
+        Doctor alice = new DoctorBuilder().withName("Alice").withPhone("12121212")
+                .withEmail("alice@wonderland.com").build();
+        Doctor other = new DoctorBuilder().withName("Bob").withPhone("99999999")
+                .withEmail("bob@wonderland.com").build();
         assertFalse(alice.isSamePerson(other));
     }
 


### PR DESCRIPTION
This PR fixes the issues identified in #241 and revises the doctor duplicate check such that the updated rule for checking duplicate doctors is as follows:

> Two doctors are considered duplicates if they share the same phone number or the same email, regardless of name. Doctors with the same name but different phone numbers and emails are allowed.

It also amends relevant test cases.

Closes #241 